### PR TITLE
Ignore/ban old nodes

### DIFF
--- a/db.h
+++ b/db.h
@@ -12,7 +12,7 @@
 
 #define MIN_RETRY 1000
 
-#define REQUIRE_VERSION 70210
+#define REQUIRE_VERSION 70213
 
 static inline int GetRequireHeight(const bool testnet = fTestNet)
 {


### PR DESCRIPTION
This one should be merged after DIP3 is active.
Merging it earlier will cause issues for legit 12.3 nodes.