### PR TITLE
Bump protocol version to 70223

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -60,7 +60,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int PROTOCOL_VERSION = 70216;
+static const int PROTOCOL_VERSION = 70223;
 
 // Used to bypass the rule against non-const reference to temporary
 // where it makes sense with wrappers such as CFlatData or CTxDB


### PR DESCRIPTION
Dash Core 18rc11 is using protocol 70223 - merge on mainnet release